### PR TITLE
Bugfix for corruption that occurs if the source url contains ampersands

### DIFF
--- a/export2enex.py
+++ b/export2enex.py
@@ -20,6 +20,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 # 
 import smtplib
+from xml.sax.saxutils import escape
 import json
 import io
 import getopt, sys
@@ -112,7 +113,7 @@ for s in item_list:
       msg_body = msg_body + "<created>" + published_datetime + "</created>"
    if updated_datetime:
       msg_body = msg_body + "<updated>" + updated_datetime + "</updated>"
-   msg_body = msg_body + "<note-attributes><source>web.clip</source><source-url>" + msg_url + "</source-url></note-attributes>"
+   msg_body = msg_body + "<note-attributes><source>web.clip</source><source-url>" + escape(msg_url) + "</source-url></note-attributes>"
    msg_body = msg_body + "</note>\r\n"
 
    print(msg_body)


### PR DESCRIPTION
url parameters can cause the exporter to generate invalid xml entities in the enex document. if the enex file has these false entities, the evernote importer stops when it parses one.
