### PR TITLE
Use tidyhtml library to clean up html before adding it to the enex content

### DIFF
--- a/export2enex.py
+++ b/export2enex.py
@@ -21,6 +21,7 @@
 # 
 import smtplib
 from xml.sax.saxutils import escape
+from tidylib import tidy_fragment
 import json
 import io
 import getopt, sys
@@ -104,10 +105,14 @@ for s in item_list:
       msg_url = d["href"].encode(char_encoding, 'replace')
    if 'summary' in s.keys():
       d = s["summary"]
-      msg_body = msg_body + d["content"].encode(char_encoding, 'replace')
+      dirtyHtml = d["content"]
+      cleanHtml, errors = tidy_fragment(dirtyHtml)
+      msg_body = msg_body + cleanHtml.encode(char_encoding, 'replace')
    if 'content' in s.keys():
       d = s["content"]
-      msg_body = msg_body + d["content"].encode(char_encoding, 'replace')
+      dirtyHtml = d["content"]
+      cleanHtml, errors = tidy_fragment(dirtyHtml)
+      msg_body = msg_body + cleanHtml.encode(char_encoding, 'replace')
    msg_body = msg_body + "</en-note>]]>\r\n</content>\r\n"
    if published_datetime:
       msg_body = msg_body + "<created>" + published_datetime + "</created>"


### PR DESCRIPTION
All the entries in my starred.json file contain unclosed <img> tags as the first element. On import to evernote, no content display. As such I use tidyhtml to correct the html before adding it to the enex file. All 1313 of my notes import and display in Evernote after this. 

I would love to conditionally include the tidyhtml library because I know it may not be part of the standard python distribution. I dont know how to conditionally include it though. Do you?
